### PR TITLE
Put method-getting logic outside of ValidatedWidget

### DIFF
--- a/misc/tkstuff/__init__.py
+++ b/misc/tkstuff/__init__.py
@@ -370,7 +370,8 @@ def get_setter(widget, setter):
                 def setter(value):
                     widget.delete(0, tk.END)
                     widget.insert(0, value)
-            elif hasattr(widget, 'selection_set') and hasattr(widget, 'selection_clear'):
+            elif (hasattr(widget, 'selection_set')
+                  and hasattr(widget, 'selection_clear')):
                 def setter(value):
                     widget.selection_clear(0, tk.END)
                     widget.selection_set(value)

--- a/misc/tkstuff/__init__.py
+++ b/misc/tkstuff/__init__.py
@@ -344,7 +344,42 @@ class ScrollableWidget(tk.Widget):
         NewClass.__qualname__ = '.'.join(NewClass.__qualname__.rsplit('.', 1)[:-1]
                                          +[NewClass.__name__])
         return NewClass
-        
+
+
+def get_getter(widget, getter):
+    if getter is None:
+        try:
+            return widget.get
+        except AttributeError:
+            try:
+                return widget.curselection
+            except AttributeError:
+                raise AttributeError('Neither a .get() nor a .curselection()'
+                                     ' were found. Please specify its name '
+                                     'in `getter`')
+    else:
+        return getattr(widget, getter)
+
+
+def get_setter(widget, setter):
+    if setter is None:
+        try:
+            return widget.set
+        except AttributeError:
+            if hasattr(widget, 'insert') and hasattr(widget, 'delete'):
+                def setter(value):
+                    widget.delete(0, tk.END)
+                    widget.insert(0, value)
+            elif hasattr(widget, 'selection_set') and hasattr(widget, 'selection_clear'):
+                def setter(value):
+                    widget.selection_clear(0, tk.END)
+                    widget.selection_set(value)
+            else:
+                raise AttributeError('No valid conbination of methods was found.'
+                                     ' Please specify the name of the method.')
+            return setter
+    else:
+        return getattr(widget, setter)
 
 
 class ValidatedWidget(tk.Widget):
@@ -367,23 +402,11 @@ class ValidatedWidget(tk.Widget):
             if validator is not None:
                 self.validator = validator
             widget.__init__(self, master, cnf, **kw)
-        if getter is None:
-            try:
-                getter = widget.get
-            except AttributeError:
-                try:
-                    getter = widget.curselection
-                except AttributeError:
-                    raise AttributeError('Neither a .get() nor a .curselection()'
-                                         ' were found. Please specify its name '
-                                         'in `getter`')
-        else:
-            getter = getattr(widget, getter)
         return type('Validated{}Widget'.format(widget.__name__),
                        (cls, widget),
                        {'__new__': object.__new__,
                         '__init__': __init__,
-                        'getter': getter,
+                        'getter': get_getter(widget, getter),
                         'validator': staticmethod(validator)}
                        )
 


### PR DESCRIPTION
Add `get_getter` and `get_setter` functions removing equivalent (for get_getter) functionality from `ValidatedWidget` body.
Allows reuse e.g. for forms